### PR TITLE
Fix HA "Mid" fan speed icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Custom [Home Assistant](https://www.home-assistant.io/) integration for **Olimpi
 ## Features
 
 - **HVAC modes**: Heat, Cool, Dry, Fan Only, Auto
-- **Fan speed**: Low, Mid, High, Auto
+- **Fan speed**: Low, Medium, High, Auto
 - **Swing**: On / Off
 - **Target temperature** control
 - **Room temperature** reading

--- a/custom_components/olimpia_splendid/climate.py
+++ b/custom_components/olimpia_splendid/climate.py
@@ -53,7 +53,7 @@ class OlimpiaClimateEntity(CoordinatorEntity[OlimpiaCoordinator], ClimateEntity)
         HVACMode.FAN_ONLY,
         HVACMode.AUTO,
     ]
-    _attr_fan_modes = ["low", "mid", "high", "auto"]
+    _attr_fan_modes = ["low", "medium", "high", "auto"]
     _attr_swing_modes = ["off", "on"]
     _attr_min_temp = 15
     _attr_max_temp = 30

--- a/custom_components/olimpia_splendid/const.py
+++ b/custom_components/olimpia_splendid/const.py
@@ -23,7 +23,7 @@ MODE_HA_TO_DEVICE = {v: k for k, v in MODE_DEVICE_TO_HA.items()}
 # Mapping fan device → stringa HA
 FAN_DEVICE_TO_HA = {
     0: "low",
-    1: "mid",
+    1: "medium",
     2: "high",
     3: "auto",
 }

--- a/custom_components/olimpia_splendid/olimpia/enums.py
+++ b/custom_components/olimpia_splendid/olimpia/enums.py
@@ -13,7 +13,7 @@ class Mode(IntEnum):
 
 class Fan(IntEnum):
     LOW = 0
-    MID = 1
+    MEDIUM = 1
     MAX = 2
     AUTO = 3
 


### PR DESCRIPTION
Fan speed icon for "mid" was just a dot icon. This change fixes the icon to match the "Low" & "High" speedo icons.